### PR TITLE
don't use bare `except:` (per PEP-8)

### DIFF
--- a/statsd.py
+++ b/statsd.py
@@ -123,7 +123,7 @@ class DogStatsd(object):
                 # tuple that is updated every time we set the host or port.
                 # Also could inline sendto.
                 self.socket.sendto(payload, (self.host, self.port))
-        except:
+        except Exception:
             logger.exception("Error submitting metric")
 
 


### PR DESCRIPTION
Per [PEP8](http://www.python.org/dev/peps/pep-0008/):

> A bare except: clause will catch SystemExit and KeyboardInterrupt exceptions, making it harder to interrupt a program with Control-C, and can disguise other problems. If you want to catch all exceptions that signal program errors, use except Exception: (bare except is equivalent to except BaseException:).
