### PR TITLE
Use a connected socket to reduce DNS lookups

### DIFF
--- a/tests/test_statsd.py
+++ b/tests/test_statsd.py
@@ -3,6 +3,7 @@ Tests for dogstatsd.py
 """
 
 from collections import deque
+import socket
 import time
 
 from nose import tools as t
@@ -16,7 +17,7 @@ class FakeSocket(object):
     def __init__(self):
         self.payloads = deque()
 
-    def sendto(self, payload, address):
+    def send(self, payload):
         self.payloads.append(payload)
 
     def recv(self):
@@ -30,8 +31,8 @@ class FakeSocket(object):
 
 class BrokenSocket(FakeSocket):
 
-    def sendto(self, payload, address):
-        raise Exception("Socket error")
+    def send(self, payload):
+        raise socket.error("Socket error")
 
 class TestDogStatsd(object):
 
@@ -131,4 +132,3 @@ class TestDogStatsd(object):
         t.assert_equal('ms', type_)
         t.assert_equal('timed.test', name)
         self.assert_almost_equal(0.5, float(value), 0.1)
-


### PR DESCRIPTION
This parallels WoLpH/python-statsd#21

I also took the time to remove the comment that was in `_send`, since this should address the intent there. And also to use a bit less string manipulation. It shouldn't matter unless someone has an obscene amount of tags, but...

We were also thinking of experimenting with adding a buffering argument to `__init__` to optionally specify a buffer to use for multiple-metric buffering. Would that be something you guys would be interested in?
