### PR TITLE
update test to python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
     - 2.6
     - 2.7
-    - 3.2
+    - 3.3
 install:
     - python setup.py install
 script:


### PR DESCRIPTION
The unicode literal was failing the tests on 3.2, and 3.3 has since
included the u'' syntax again.
Ref: http://www.python.org/dev/peps/pep-0414/
