### PR TITLE
Restore accidentally removed global statsd instance.

### DIFF
--- a/statsd.py
+++ b/statsd.py
@@ -177,3 +177,6 @@ class DogStatsd(object):
             self.socket.send(string)
         except Exception:
             log.exception(u'Error submitting event "%s"' % title)
+
+
+statsd = DogStatsd()

--- a/tests/test_statsd.py
+++ b/tests/test_statsd.py
@@ -10,6 +10,7 @@ import time
 from nose import tools as t
 
 from statsd import DogStatsd
+import statsd
 
 
 class FakeSocket(object):
@@ -140,6 +141,9 @@ class TestDogStatsd(object):
         t.assert_equal('ms', type_)
         t.assert_equal('timed.test', name)
         self.assert_almost_equal(0.5, float(value), 0.1)
+
+    def test_module_level_instance(self):
+        t.assert_is_instance(statsd.statsd, statsd.DogStatsd)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
8d6a3543289f88db55c78201d598b43101ccd899 seems to have accidentally removed the global statsd instance.
