### PR TITLE
Metrics batching

### DIFF
--- a/statsd.py
+++ b/statsd.py
@@ -178,7 +178,7 @@ class DogStatsd(object):
 
     def _send_to_buffer(self, packet):
         self.buffer.append(packet)
-        if len(self.buffer) > self.max_buffer_size:
+        if len(self.buffer) >= self.max_buffer_size:
             self._flush_buffer()
 
     def _flush_buffer(self):

--- a/tests/test_statsd.py
+++ b/tests/test_statsd.py
@@ -159,6 +159,15 @@ class TestDogStatsd(object):
 
         t.assert_equal('page.views:123|g\ntimer:123|ms', fake_socket.recv())
 
+    def test_batched_buffer_autoflush(self):
+        fake_socket = FakeSocket()
+        with DogStatsd() as statsd:
+            statsd.socket = fake_socket
+            for i in range(51):
+                statsd.increment('mycounter')
+            t.assert_equal('\n'.join(['mycounter:1|c' for i in range(50)]), fake_socket.recv())
+
+        t.assert_equal('mycounter:1|c', fake_socket.recv())
 
     def test_module_level_instance(self):
         t.assert_true(isinstance(statsd.statsd, statsd.DogStatsd))


### PR DESCRIPTION
Allow to send several metrics in one UDP packets, by separating them with `\n`

Can be used as a context manager:

``` python
with DogStatsd() as batched_statsd:
    batched_statsd.gauge('my.gauge', 10)
    batched_statsd.timing('my.timer', 123)

```

will send them both in a single packet. If too many metrics are to be sent at the same time, they are going to be sent into several packets to avoid the limitations due to the UDP packets size.

@clutchski 
