### PR TITLE
Try to refresh the socket when sending a message fails

### DIFF
--- a/statsd.py
+++ b/statsd.py
@@ -177,7 +177,12 @@ class DogStatsd(object):
         try:
             self.socket.send(packet.encode(self.encoding))
         except socket.error:
-            log.exception("Error submitting metric")
+            log.info("Error submitting metric, will try refreshing the socket")
+            self.connect(self._host, self._port)
+            try:
+                self.socket.send(packet.encode(self.encoding))
+            except socket.error:
+                log.exception("Failed to send packet with a newly binded socket")
 
     def _send_to_buffer(self, packet):
         self.buffer.append(packet)


### PR DESCRIPTION
Should address #20  (Could not reproduce the bug the user is seeing but this should work)

`[Errno 9] Bad file descriptor` happens when trying to write to a socket that has been closed. This change try to use a new socket when this happens.
