### PR TITLE
Don't be such a rude dude (don't open sockets so eagerly)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Make your change. Add tests for your change. Make the tests pass:
 
 Push to your fork and [submit a pull request][pr].
 
-[pr]: https://github.com/DataDog/dogstatsd-python/compare/
+[pr]: https://github.com/your-username/dogstatsd-python/compare/DataDog:master...master
 
 At this point you're waiting on us. We may suggest some changes or
 improvements or alternatives.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing
+
+We love pull requests. Here's a quick guide.
+
+Fork, then clone the repo:
+
+    git clone git@github.com:your-username/dogstatsd-python.git
+
+Make sure the tests pass:
+
+    pip install nosetests; python setup.py test
+
+Make your change. Add tests for your change. Make the tests pass:
+
+    python setup.py test
+
+Push to your fork and [submit a pull request][pr].
+
+[pr]: https://github.com/DataDog/dogstatsd-python/compare/
+
+At this point you're waiting on us. We may suggest some changes or
+improvements or alternatives.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Fork, then clone the repo:
 
 Make sure the tests pass:
 
-    pip install nosetests; python setup.py test
+    pip install nose six; python setup.py test
 
 Make your change. Add tests for your change. Make the tests pass:
 

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,6 @@ setup(
     py_modules=['statsd'],
     license = "BSD",
     keywords = "datadog data statsd metrics",
-    url = "http://www.datadoghq.com"
+    url = "http://www.datadoghq.com",
+    test_suite = "nose.collector"
 )

--- a/tests/test_statsd.py
+++ b/tests/test_statsd.py
@@ -174,6 +174,25 @@ class TestDogStatsd(object):
     def test_module_level_instance(self):
         t.assert_true(isinstance(statsd.statsd, statsd.DogStatsd))
 
+    def test_instantiating_does_not_connect(self):
+        dogpound = DogStatsd()
+        t.assert_is_none(dogpound._socket)
+
+    def test_accessing_socket_opens_socket(self):
+        dogpound = DogStatsd()
+        try:
+            t.assert_is_not_none(dogpound.socket)
+        finally:
+            dogpound.socket.close()
+
+    def test_accessing_socket_multiple_times_returns_same_socket(self):
+        dogpound = DogStatsd()
+        fresh_socket = FakeSocket()
+        dogpound.socket = fresh_socket
+        t.assert_equal(fresh_socket, dogpound.socket)
+        t.assert_not_equal(FakeSocket(), dogpound.socket)
+
+
 
 if __name__ == '__main__':
     statsd = statsd

--- a/tests/test_statsd.py
+++ b/tests/test_statsd.py
@@ -176,12 +176,12 @@ class TestDogStatsd(object):
 
     def test_instantiating_does_not_connect(self):
         dogpound = DogStatsd()
-        t.assert_is_none(dogpound._socket)
+        t.assert_equal(None, dogpound._socket)
 
     def test_accessing_socket_opens_socket(self):
         dogpound = DogStatsd()
         try:
-            t.assert_is_not_none(dogpound.socket)
+            t.assert_not_equal(None, dogpound.socket)
         finally:
             dogpound.socket.close()
 


### PR DESCRIPTION
It's pretty nasty to instantiate an instance of `DogStatsd` when you import the module. It's even nastier to open a socket when you instantiate it. Doing things this way means you'll __ALWAYS__ open a connection, even when you replace the socket later.

Now, we'll only open a socket the first time a property is accessed. We'll also cache the socket so we don't need to make multiple connections, which seems like was the intent when connecting on instantiation was added in DataDog/dogstatsd-python@7b98b7829013f8a21b0fedb1c2a68ff3fc0afedc.

I think this module should be separated into `statsd.py` and `dogstatsd.py` so it's easy to import and use an instance without having one created at import time. I didn't do that here because it makes the diff tougher. I can add implement that if/when this is accepted.

From a high-level:
- Added a `socket` property for accessing a cached, connected socket
- Added tests for newly added properties
- Corrected a few PEP8 violations (there are more, but tried not to go crazy)
- Configured `setup.py` so you can run `python setup.py test` and it'll do the right thing (assuming you have nose installed, which the test already requires)
- Added a guide for how to contribute to this project