### PR TITLE
Prevent RuntimeError: error('illegal IP address string passed to inet_pt...

### DIFF
--- a/statsd.py
+++ b/statsd.py
@@ -35,7 +35,7 @@ class DogStatsd(object):
         self.socket = None
         self.max_buffer_size = max_buffer_size
         self._send = self._send_to_server
-        self.connect(host, port)
+        #self.connect(host, port)
         self.encoding = 'utf-8'
 
 


### PR DESCRIPTION
If you try and use dogstatsd-python on appengine, their implementation of sockets throws the following error. Not calling connect durring init fixes this..

File "/Users/ryanbonham/Projects/amplified-vine-651/default/lib/statsd.py", line 266, in <module>
    statsd = DogStatsd()
  File "/Users/ryanbonham/Projects/amplified-vine-651/default/lib/statsd.py", line 38, in __init__
    self.connect(host, port)
  File "/Users/ryanbonham/Projects/amplified-vine-651/default/lib/statsd.py", line 78, in connect
    self.socket.connect((self._host, self._port))
  File "/Users/ryanbonham/google-cloud-sdk/platform/google_appengine/google/appengine/dist27/socket.py", line 222, in meth
    return getattr(self._sock,name)(*args)
  File "/Users/ryanbonham/google-cloud-sdk/platform/google_appengine/google/appengine/api/remote_socket/_remote_socket.py", line 752, in connect
    address_hostname_hint=_hostname_hint)
  File "/Users/ryanbonham/google-cloud-sdk/platform/google_appengine/google/appengine/api/remote_socket/_remote_socket.py", line 590, in _CreateSocket
    address_hostname_hint)
  File "/Users/ryanbonham/google-cloud-sdk/platform/google_appengine/google/appengine/api/remote_socket/_remote_socket.py", line 633, in _SetProtoFromAddr
    proto.set_packed_address(self._GetPackedAddr(address))
  File "/Users/ryanbonham/google-cloud-sdk/platform/google_appengine/google/appengine/api/remote_socket/_remote_socket.py", line 628, in _GetPackedAddr
    AI_NUMERICSERV|AI_PASSIVE):
  File "/Users/ryanbonham/google-cloud-sdk/platform/google_appengine/google/appengine/api/remote_socket/_remote_socket.py", line 339, in getaddrinfo
    canonical=(flags & AI_CANONNAME))
  File "/Users/ryanbonham/google-cloud-sdk/platform/google_appengine/google/appengine/api/remote_socket/_remote_socket.py", line 212, in _Resolve
    canon, aliases, addresses = _ResolveName(name, families)
  File "/Users/ryanbonham/google-cloud-sdk/platform/google_appengine/google/appengine/api/remote_socket/_remote_socket.py", line 230, in _ResolveName
    apiproxy_stub_map.MakeSyncCall('remote_socket', 'Resolve', request, reply)
  File "/Users/ryanbonham/google-cloud-sdk/platform/google_appengine/google/appengine/api/apiproxy_stub_map.py", line 95, in MakeSyncCall
    return stubmap.MakeSyncCall(service, call, request, response)
  File "/Users/ryanbonham/google-cloud-sdk/platform/google_appengine/google/appengine/api/apiproxy_stub_map.py", line 329, in MakeSyncCall
    rpc.CheckSuccess()
  File "/Users/ryanbonham/google-cloud-sdk/platform/google_appengine/google/appengine/api/apiproxy_rpc.py", line 157, in _WaitImpl
    self.request, self.response)
  File "/Users/ryanbonham/google-cloud-sdk/platform/google_appengine/google/appengine/ext/remote_api/remote_api_stub.py", line 201, in MakeSyncCall
    self._MakeRealSyncCall(service, call, request, response)
  File "/Users/ryanbonham/google-cloud-sdk/platform/google_appengine/google/appengine/ext/remote_api/remote_api_stub.py", line 235, in _MakeRealSyncCall
    raise pickle.loads(response_pb.exception())
RuntimeError: error('illegal IP address string passed to inet_pton',)