### PR TITLE
Avoid usage of property for socket

### DIFF
--- a/tests/test_statsd.py
+++ b/tests/test_statsd.py
@@ -45,7 +45,7 @@ class TestDogStatsd(object):
         self.statsd.socket = FakeSocket()
 
     def recv(self):
-        return self.statsd.socket.recv()
+        return self.statsd.get_socket().recv()
 
     def test_set(self):
         self.statsd.set('set', 123)
@@ -89,7 +89,7 @@ class TestDogStatsd(object):
         assert not self.recv()
         for i in range(10000):
             self.statsd.increment('sampled_counter', sample_rate=0.3)
-        self.assert_almost_equal(3000, len(self.statsd.socket.payloads), 150)
+        self.assert_almost_equal(3000, len(self.statsd.get_socket().payloads), 150)
         t.assert_equal('sampled_counter:1|c|@0.3', self.recv())
 
     def test_tags_and_samples(self):
@@ -184,22 +184,21 @@ class TestDogStatsd(object):
 
     def test_instantiating_does_not_connect(self):
         dogpound = DogStatsd()
-        t.assert_equal(None, dogpound._socket)
+        t.assert_equal(None, dogpound.socket)
 
     def test_accessing_socket_opens_socket(self):
         dogpound = DogStatsd()
         try:
-            t.assert_not_equal(None, dogpound.socket)
+            t.assert_not_equal(None, dogpound.get_socket())
         finally:
-            dogpound.socket.close()
+            dogpound.get_socket().close()
 
     def test_accessing_socket_multiple_times_returns_same_socket(self):
         dogpound = DogStatsd()
         fresh_socket = FakeSocket()
         dogpound.socket = fresh_socket
-        t.assert_equal(fresh_socket, dogpound.socket)
-        t.assert_not_equal(FakeSocket(), dogpound.socket)
-
+        t.assert_equal(fresh_socket, dogpound.get_socket())
+        t.assert_not_equal(FakeSocket(), dogpound.get_socket())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Workaround `@property` usage to avoid potential performance degradation (Fixes #29, thanks @Julian.)
Added some refactoring

Benchmarking
===========
### Bench test
```python
from statsd import statsd


class TestStatsdPerf(object):

    def test_statsd_perf(self):
        for i in xrange(100000):
            statsd.gauge('my.gauge', 1)
            statsd.increment('my.counter')


if __name__ == '__main__':
    t = TestStatsdPerf()
    t.test_statsd_perf()

```
**Method**: Reiterating 5 times, and keep the best score (minimum execution time)

### Branch results
```
-> % python -m cProfile -s cumtime tests/statsd_benchmark.py
         1210794 function calls in 2.485 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    2.485    2.485 property_benchmark.py:1(<module>)
        1    0.112    0.112    2.470    2.470 property_benchmark.py:6(test_statsd_perf)
   200000    0.263    0.000    2.230    0.000 statsd.py:164(_report)
   200000    0.173    0.000    1.538    0.000 statsd.py:177(_send_to_server)
   100000    0.064    0.000    1.181    0.000 statsd.py:80(gauge)
   100000    0.064    0.000    1.177    0.000 statsd.py:90(increment)
   200466    1.030    0.000    1.030    0.000 {method 'send' of '_socket.socket' objects}
   200000    0.429    0.000    0.429    0.000 {method 'join' of 'str' objects}
   200466    0.194    0.000    0.194    0.000 {method 'encode' of 'str' objects}
      467    0.003    0.000    0.140    0.000 statsd.py:49(get_socket)
```
### 0.5.4 results
```
-> % python -m cProfile -s cumtime tests/property_benchmark.py
         1410847 function calls in 2.639 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    2.639    2.639 property_benchmark.py:1(<module>)
        1    0.117    0.117    2.620    2.620 property_benchmark.py:6(test_statsd_perf)
   200000    0.295    0.000    2.368    0.000 statsd.py:173(_report)
   200000    0.259    0.000    1.650    0.000 statsd.py:186(_send_to_server)
   100000    0.068    0.000    1.258    0.000 statsd.py:89(gauge)
   100000    0.066    0.000    1.245    0.000 statsd.py:99(increment)
   200448    1.056    0.000    1.056    0.000 {method 'send' of '_socket.socket' objects}
   200000    0.424    0.000    0.424    0.000 {method 'join' of 'str' objects}
   200448    0.183    0.000    0.183    0.000 {method 'encode' of 'str' objects}
   200448    0.050    0.000    0.148    0.000 statsd.py:49(socket)
      449    0.001    0.000    0.092    0.000 socket.py:223(meth)
```
### 0.5.3 results
```
-> % python -m cProfile -s cumtime tests/property_benchmark.py
         1209232 function calls in 2.477 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    2.477    2.477 property_benchmark.py:1(<module>)
        1    0.121    0.121    2.457    2.457 property_benchmark.py:6(test_statsd_perf)
   200000    0.265    0.000    2.199    0.000 statsd.py:164(_report)
   200000    0.169    0.000    1.497    0.000 statsd.py:177(_send_to_server)
   100000    0.071    0.000    1.172    0.000 statsd.py:90(increment)
   100000    0.067    0.000    1.164    0.000 statsd.py:80(gauge)
   200395    1.019    0.000    1.019    0.000 {method 'send' of '_socket.socket' objects}
   200000    0.437    0.000    0.437    0.000 {method 'join' of 'str' objects}
   200395    0.206    0.000    0.206    0.000 {method 'encode' of 'str' objects}
      396    0.004    0.000    0.103    0.000 statsd.py:71(connect)
```