### PR TITLE
don't send None to statsd daemon as metric value

### DIFF
--- a/statsd.py
+++ b/statsd.py
@@ -114,6 +114,7 @@ class DogStatsd(object):
         """
         if value is None:
             return
+
         self._report(metric, 'c', -value, tags, sample_rate)
 
     def histogram(self, metric, value, tags=None, sample_rate=1):

--- a/statsd.py
+++ b/statsd.py
@@ -112,6 +112,8 @@ class DogStatsd(object):
         >>> statsd.decrement('files.remaining')
         >>> statsd.decrement('active.connections', 2)
         """
+        if value is None:
+            return
         self._report(metric, 'c', -value, tags, sample_rate)
 
     def histogram(self, metric, value, tags=None, sample_rate=1):
@@ -169,6 +171,9 @@ class DogStatsd(object):
         self._report(metric, 's', value, tags, sample_rate)
 
     def _report(self, metric, metric_type, value, tags, sample_rate):
+        if value is None:
+            return
+
         if sample_rate != 1 and random() > sample_rate:
             return
 

--- a/tests/test_statsd.py
+++ b/tests/test_statsd.py
@@ -182,6 +182,26 @@ class TestDogStatsd(object):
     def test_module_level_instance(self):
         t.assert_true(isinstance(statsd.statsd, statsd.DogStatsd))
 
+    def test_it_wont_allow_None_for_gauge(self):
+        self.statsd.gauge('set', None)
+        assert self.recv() is None
+
+    def test_it_wont_allow_None_for_increment(self):
+        self.statsd.increment('set', None)
+        assert self.recv() is None
+
+    def test_it_wont_allow_None_for_decrement(self):
+        self.statsd.decrement('set', None)
+        assert self.recv() is None
+
+    def test_it_wont_allow_None_for_histogram(self):
+        self.statsd.histogram('set', None)
+        assert self.recv() is None
+
+    def test_it_wont_allow_None_for_timing(self):
+        self.statsd.timing('set', None)
+        assert self.recv() is None
+
 
 if __name__ == '__main__':
     statsd = statsd


### PR DESCRIPTION
If you do, you'll get errors like this in `/var/log/messages`: 

```
Metric value must be a number: metric.name, None
```
